### PR TITLE
Fix TypeScript build errors - Replace derived loading states with useState

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -229,10 +229,9 @@ function MainApp() {
   const competitors = parsedScrapedData?.competitors || [];
   const hasCompetitors = competitors.length > 0;
 
-  // Derived loading states based on data presence
-  const hasFounders = parsedScrapedData?.founders && parsedScrapedData.founders.length > 0;
-  const isEnrichingFounders = hasFounders && parsedScrapedData.founders.some((f: any) => !f.bio || f.bio === "None");
-  const isDeepResearching = (isAnalyzing || isRerunning) && hasFounders && !hasCompetitors;
+  // Loading states for founder story and competitive landscape
+  const [isDeepResearching, setIsDeepResearching] = useState(false);
+  const [isEnrichingFounders, setIsEnrichingFounders] = useState(false);
 
   const recentNewsItems = useMemo(() => {
     if (!hypeRecentNews) {


### PR DESCRIPTION
## Problem
The previous PR merge resulted in TypeScript build errors because `isEnrichingFounders` and `isDeepResearching` were defined as derived computed values, but the code was trying to call `setIsEnrichingFounders()` and `setIsDeepResearching()` which don't exist for computed values.

## Solution
Replaced the derived computed values with proper `useState` declarations so the setters exist.

## Changes
- Changed `isEnrichingFounders` from derived value to `useState(false)`
- Changed `isDeepResearching` from derived value to `useState(false)`

## Testing
✅ Build passes: `npm run build`
✅ No TypeScript errors

## Fixes Errors
- ❌ Cannot find name 'setIsEnrichingFounders'
- ❌ Cannot find name 'setIsDeepResearching'

Co-Authored-By: Claude <noreply@anthropic.com>